### PR TITLE
keeps item attributes when decoding lists

### DIFF
--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -346,7 +346,7 @@ class XmlEncoder extends SerializerAwareEncoder implements EncoderInterface, Dec
             $val = $this->parseXml($subnode);
 
             if ('item' === $subnode->nodeName && isset($val['@key'])) {
-                if (isset($val['#'])) {
+                if (isset($val['#']) && count(array_keys($val)) == 2) {
                     $value[$val['@key']] = $val['#'];
                 } else {
                     $value[$val['@key']] = $val;


### PR DESCRIPTION
XmlEncoder Keeps the attributes for list items on decoding even if they are basic types or empty, but only when they have any attribute beside @key.

| Q             | A
| ------------- | ---
| Branch?       | 2.8
| Bug fix?      | no
| New feature?  | no <!-- don't forget updating src/**/CHANGELOG.md files -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget updating UPGRADE-*.md files -->
| Tests pass?   | no
| License       | MIT

<!--
- Bug fixes must be submitted against the lowest branch where they apply
  (lowest branches are regularly merged to upper ones so they get the fixes too).
- Features and deprecations must be submitted against the 3.4,
  legacy code removals go to the master branch.
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->
